### PR TITLE
Rio - Make mktemp call with explicit template to handle OSX version of mktemp

### DIFF
--- a/Rio
+++ b/Rio
@@ -40,12 +40,14 @@ DELIMITER=","
 HEADER="T"
 VERBOSE=false
 
+# OSX `mktemp' requires a temp file template, but Linux `mktemp' has it as optional.
+# This explicitly uses a template, which works for both.  The $TMPDIR is in case
+# it isn't set as an enviroment variable, assumes you have /tmp.
 if [ -z "$TMPDIR" ]; then
     TMPDIR=/tmp/
 fi
 IN=$(mktemp ${TMPDIR}Rio-XXXXXXXX)
 OUT=$(mktemp ${TMPDIR}Rio-XXXXXXXX).png
-
 
 while getopts "d:hgnpsve:" OPTION
 do


### PR DESCRIPTION
OSX `mktemp' requires a temp file template, but Linux`mktemp' has it as optional.  This explicitly uses a template, which works for both.  The $TMPDIR is in case it isn't set as an enviroment variable, assumes you have /tmp.
