### PR TITLE
Update `sample` to run on Python 2.5

### DIFF
--- a/sample
+++ b/sample
@@ -3,7 +3,7 @@
 # 
 # Example usage: seq 100 | sample -r 20% -d 1000
 #
-# Dependency: Python 2.7
+# Dependency: Python 2.5
 # 
 # Author: http://jeroenjanssens.com
 


### PR DESCRIPTION
Hello!

Since I'm using a rather old machine which has only up to Python 2.6 available, I had to perform some changes to the code in order to run it on older versions.

It seems that the only dependance from Python 2.7 is for the package `argparse`, but the code doesn't actually use its extended capabilities against its predecessor, `optparse`.   I don't know about the future, but currently it doesn't bother to use the older package for this job.

Also, method `datetime.timedelta.total_seconds()` is an addition to Python 2.7, but it's quite trivial to implement it and use it as a module function.

Luckily, after applying these small changes I figured out that `sample` can be executed even by Python 2.5!

Yet, most programs lack any unit tests and some may perform better with some refactoring.  Do you mind if I change a bit the codebase?
