### PR TITLE
added install for qstats in bootstrap

### DIFF
--- a/box/bootstrap.sh
+++ b/box/bootstrap.sh
@@ -35,6 +35,12 @@ tar -xjf parallel-latest.tar.bz2
 cd $(find -name 'parallel-*' -type d)
 ./configure && make && sudo make install
 
+log 'Installing qstats...'
+cd $DOWNLOADS
+git clone https://github.com/tonyfischetti/qstats.git
+cd qstats
+make && make install
+
 log 'Installing jq...'
 cd $TOOLS
 wget http://stedolan.github.io/jq/download/linux64/jq


### PR DESCRIPTION
I added shell code to clone stats from github, make, and install it. I put it under GNU parallel (and above jq) so it could be in the $DOWNLOADS directory that is later purged
