### PR TITLE
Add new `rawinput` option to the Scrape tool

### DIFF
--- a/tools/scrape
+++ b/tools/scrape
@@ -19,6 +19,7 @@ def main():
     parser.add_argument('-t', '--text', action='store_true', default=False, help="Output text instead of HTML")
     parser.add_argument('-b', '--body', action='store_true', default=False, help="Enclose output with HTML and BODY tags")
     parser.add_argument('-d', '--delimiter', default=' ', help="Delimiter when output is text")
+    parser.add_argument('-r', '--rawinput', action='store_true', default=False, help="Do not parse HTML before feeding etree (useful for escaping CData)")
     args = parser.parse_args()
 
     if not args.expression.startswith('//'):
@@ -30,8 +31,11 @@ def main():
     else:
         expression = args.expression
 
-    html_parser = etree.HTMLParser(encoding='utf-8', recover=True)
-    document = etree.parse(args.html, html_parser)
+    html_parser = etree.HTMLParser(encoding='utf-8', recover=True, strip_cdata=True)
+    if args.rawinput:
+      document = etree.fromstring(args.html.read())
+    else:
+      document = etree.parse(args.html, html_parser)
 
     if args.body:
         sys.stdout.write("<!DOCTYPE html>\n<html>\n<body>\n")


### PR DESCRIPTION
This new `rawInput` option enable to correctly get back CData contents with XPath expressions
#### Use case:

Given a very simple `test.xml` file:

```
<?xml version="1.0" encoding="utf-8"?>
<response>
    <type><![CDATA[Success]]></type>
    <data>
        <element>
            <k class="Element">
                <licenceId>17</licenceId>
            </k>
        </element>
    </data>
</response>
```

Current parsing does ignore CData

```
$ cat test.xml | scrape -e '//response'
<response>
    <type/>
    <data>
        <element>
            <k class="BkElement">
                <licenceid>17</licenceid>
            </k>
        </element>
    </data>
</response>
```

Here's the expected result, with the CData content

```
$ cat test.xml | scrape -r -e '//response'
<response>
    <type>Success</type>
    <data>
        <element>
            <k class="BkElement">
                <licenceId>17</licenceId>
            </k>
        </element>
    </data>
</response>
```
