### PR TITLE
Add 'attribute' option to scrape tool

### DIFF
--- a/tools/scrape
+++ b/tools/scrape
@@ -41,12 +41,10 @@ def main():
         try:
             if not args.argument :
                 text = etree.tostring(e)
-	    else:
-		    if e.get(args.argument) != None:
-			    text = e.get(args.argument)
-		    else:
-			    text = "No corresponding attribute in matching tag"
-            sys.stdout.write(text.encode('utf-8') + "\n")
+            else:
+                text = e.get(args.argument)
+            if text != None:
+                sys.stdout.write(text.encode('utf-8') + "\n")
             sys.stdout.flush()
         except IOError:
             pass


### PR DESCRIPTION
The idea is to provide an "attribute" option to scrape tag's attribute value (not tag content itself). 

<h3>Use case</h3>

With the many frontend libraries available now, we often encounter data embedded in a tag attribute, let's take the following test.html example:

```
<section>
    <h1>Title</h1>
    <div>
        <div class='interesting' data-entries="{&quot;entries&quot;:[{&quot;id&quot;:1,&quot;name&quot;:&quot;thefirst&quot;},{&quot;id&quot;:2,&quot;name&quot;:&quot;thesecond&quot;}]}">
            <span>Some interesting content</span>
        </div>
        <div class='interesting'>
            <span>Some other interesting content</span>
        </div>
        <div class='interesting' data-entries="{&quot;entries&quot;:[{&quot;id&quot;:8,&quot;name&quot;:&quot;thetenth&quot;}]}">
            <span>Some interesting content</span>
        </div>

    </div>
</section>
```

to extract the "data-entries" attribute value from the matching tags (having the specified attribute) , we can then use:

```
$ scrape -e ".interesting" -a "data-entries" test.html 
{"entries":[{"id":1,"name":"thefirst"},{"id":2,"name":"thesecond"}]}
{"entries":[{"id":8,"name":"thetenth"}]}
```
