### PR TITLE
make Rio work when TMPDIR does not end with a trailing slash

### DIFF
--- a/tools/Rio
+++ b/tools/Rio
@@ -60,9 +60,9 @@ DPI=72
 if [ -z "$TMPDIR" ]; then
     TMPDIR=/tmp/
 fi
-IN=$(mktemp ${TMPDIR}Rio-XXXXXXXX)
-OUT=$(mktemp ${TMPDIR}Rio-XXXXXXXX).png
-ERR=$(mktemp ${TMPDIR}Rio-XXXXXXXX).err
+IN=$(mktemp ${TMPDIR}/Rio-XXXXXXXX)
+OUT=$(mktemp ${TMPDIR}/Rio-XXXXXXXX).png
+ERR=$(mktemp ${TMPDIR}/Rio-XXXXXXXX).err
 
 while getopts "d:hgnprsve:f:b" OPTION
 do


### PR DESCRIPTION
This change makes Rio work when $TMPDIR does not end with a trailing slash and the user lacks write permissions on $TMPDIR's parent directory.

For example, on one of my Ubuntu machines, my TMPDIR is set to /tmp/user/1001 (where 1001 is my userid) and /tmp/user/ is owned by root, mode 711.
