### PR TITLE
Exit with 0

### DIFF
--- a/tools/header
+++ b/tools/header
@@ -62,24 +62,24 @@ do
 		a)
 			print_header "$OPTARG\n"
 			print_body
-			exit 1
+			exit 0
 			;;
 		d)
 			get_header
 			print_body
-			exit 1
+			exit 0
 			;;
 		r)
 			get_header
 			print_header "$OPTARG\n"
 			print_body
-			exit 1
+			exit 0
 			;;
 		e)
 			get_header
 			print_header "$(echo -ne $OLDHEADER | eval $OPTARG)\n"
 			print_body
-			exit 1
+			exit 0
 			;;
 		h)
 			usage


### PR DESCRIPTION
Correct usage should not exit with 1, which prevents this script from working correctly in combination with other scripts.
