### PR TITLE
Link book image to O'Reilly Store Page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Data Science at the Command Line
 ================================
 
-![Data Science at the Command Line Cover](book/.cover.png)
+[![Data Science at the Command Line Cover](book/.cover.png)](http://shop.oreilly.com/product/0636920032823.do)
 
 This repository contains the virtual machine, data, scripts, and custom command-line tools used in the book [Data Science at the Command Line](http://datascienceatthecommandline.com).
 ## License


### PR DESCRIPTION
This seems useful for you, @jeroenjanssens – a direct link to the book's page on the O'Reilly website (instead of just linking to the image here in github).

Thanks for your hard work!