### PR TITLE
make clear to use python2

### DIFF
--- a/book/02.Rmd
+++ b/book/02.Rmd
@@ -196,7 +196,7 @@ Interpreted Script
 
     ```{example script-fac, name="Python script that computes the factorial of an integer"}
     ```
-    ```{python, eval=FALSE}
+    ```{python2, eval=FALSE}
     ##!/usr/bin/env python
 
     def factorial(x):


### PR DESCRIPTION
Dear Jeroen,
thanks for this interesting book which I will read over Christmas! When compiling the book using **bookdown**, I had to explicitly state that we want to use Python2. The default on my machine is Python3, and I guess this is the case for most other users as well, and if this is not already the case, it will be in the coming years. Hence, using Python2 is just a quick-and-dirty fix, maybe the better idea is to rewrite the code snippet using Python3. Should I do that?