### PR TITLE
Ch 5 add arguments to header

### DIFF
--- a/book/05.Rmd
+++ b/book/05.Rmd
@@ -15,7 +15,7 @@ $ printf 'foo\nbar\nfoo' | sort | uniq -c | sort -nr
       2 foo
       1 bar
 $ printf 'foo\nbar\nfoo' | sort | uniq -c | sort -nr |
-> awk '{print $2","$1}' | header -a
+> awk '{print $2","$1}' | header -a 'value, count'
 value,count
 foo,2
 bar,1

--- a/book/05.Rmd
+++ b/book/05.Rmd
@@ -11,10 +11,10 @@ Once our data is in the format we want it to be, we can apply common scrubbing o
 The scrubbing tasks that we discuss in this chapter not only apply to the input data. Sometimes, we also need to reformat the output of some command-line tools. For example, to transform the output of `uniq -c` to a CSV data set, we could use `awk` [@awk] and `header`:
 
 ```{bash, eval=FALSE}
-$ echo 'foo\nbar\nfoo' | sort | uniq -c | sort -nr
+$ printf 'foo\nbar\nfoo' | sort | uniq -c | sort -nr
       2 foo
       1 bar
-$ echo 'foo\nbar\nfoo' | sort | uniq -c | sort -nr |
+$ printf 'foo\nbar\nfoo' | sort | uniq -c | sort -nr |
 > awk '{print $2","$1}' | header -a
 value,count
 foo,2


### PR DESCRIPTION
`header -a` requires an argument for the header. In this case, it is the csv header string `'value, count'`. 